### PR TITLE
MacOS support, with missing features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,12 @@ mod linux;
 #[cfg(target_os = "linux")]
 pub use linux::get_serial_list;
 
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[cfg(target_os = "macos")]
+pub use macos::get_serial_list;
+
 #[derive(Debug)]
 /// usb information of serial port
 pub struct UsbInfo {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,0 +1,29 @@
+use crate::{SerialInfo};
+use std::fs;
+use std::vec::Vec;
+
+fn get_device_files() -> impl Iterator<Item=fs::DirEntry> {
+    const DEV_PATH: &str = "/dev";
+    let read_dir = fs::read_dir(DEV_PATH).expect("could not list the /dev directory");
+    return read_dir.filter_map(|entry| entry.ok());
+}
+
+/// enumerate all avaliable serial port
+pub fn get_serial_list() -> Vec<SerialInfo> {
+    let devices = get_device_files();
+
+    let paths = devices.map(|d| d.path()
+                                 .to_str()
+                                 .expect(format!("could not convert file name to string: {:?}", d).as_str())
+                                 .to_string());
+    
+    let serial_devices = paths.filter(|path| path.starts_with("/dev/cu"));
+
+    return serial_devices.map(|d| SerialInfo {
+        name: d.to_string(),
+        driver: None,
+        vendor: None,
+        product: None,
+        usb_info: None
+    }).collect();
+}


### PR DESCRIPTION
A first start on solving issue #1 .

This is only a simple implementation that lists the serial devices in the /dev directory. More advanced features such as the retrieval of vendor, and product information have not been implemented.